### PR TITLE
Replace lens dependency with lens-simple

### DIFF
--- a/genCabal.hs
+++ b/genCabal.hs
@@ -24,15 +24,15 @@ quickCheck = package "QuickCheck" (gtEq [2,7])
 process :: Package
 process = package "process" (gtEq [1,2])
 
-lens :: Package
-lens = package "lens" (gtEq [4,7])
+lensSimple :: Package
+lensSimple = package "lens-simple" (gtEq [0,1,0,8])
 
 commonOptions :: HasBuildInfo a => [a]
 commonOptions =
   [ haskell2010
   , ghcOptions ["-Wall"]
   , otherExtensions ["TemplateHaskell"]
-  , buildDepends [base, text, bytestring, process, lens]
+  , buildDepends [base, text, bytestring, process, lensSimple]
   , hsSourceDirs ["lib"]
   ]
 

--- a/lib/Rainbow.hs
+++ b/lib/Rainbow.hs
@@ -154,7 +154,6 @@ module Rainbow
 
   -- * Re-exports
   -- $reexports
-  , module Control.Lens.Operators
   , module Data.Word
   , module Data.ByteString
   , module Data.Monoid
@@ -164,13 +163,14 @@ module Rainbow
 
   ) where
 
+import           Data.ByteString   (ByteString)
+import           Data.Monoid       (Monoid (mempty), (<>))
+import           Data.Word         (Word8)
 import qualified Rainbow.Translate as T
-import qualified Rainbow.Types as Y
-import Data.Word (Word8)
-import Data.ByteString (ByteString)
-import Control.Lens.Operators ((&))
-import Control.Lens
-import Data.Monoid (Monoid(mempty), (<>))
+import qualified Rainbow.Types     as Y
+
+import           Lens.Simple
+
 
 formatBoth :: Setter' Y.Format Bool -> Y.Chunk a -> Y.Chunk a
 formatBoth get c = c & Y.scheme . Y.style8 . Y.format . get .~ True
@@ -228,7 +228,7 @@ back (Y.Radiant c8 c256) c = c & Y.scheme . Y.style8 . Y.back .~ c8
 --    'fore' ('blue' <> 'only256' 'red')
 -- @
 only256 :: Y.Radiant -> Y.Radiant
-only256 r = r & Y.color8 . _Wrapped .~ Nothing
+only256 r = r & Y.color8 .~ Y.Color Nothing
 
 black :: Y.Radiant
 black = Y.Radiant (Y.Color (Just Y.E0)) (Y.Color (Just 0))

--- a/lib/Rainbow/Types.hs
+++ b/lib/Rainbow/Types.hs
@@ -12,14 +12,15 @@ module Rainbow.Types where
 
 -- # Imports
 
-import Control.Lens
-import Data.Foldable ()
-import Data.Foldable (Foldable)
-import Data.Monoid
-import Data.Traversable ()
-import Data.Typeable
-import Data.Word (Word8)
-import GHC.Generics
+import           Data.Foldable    ()
+import           Data.Foldable    (Foldable)
+import           Data.Monoid
+import           Data.Traversable ()
+import           Data.Typeable
+import           Data.Word        (Word8)
+import           GHC.Generics
+
+import           Lens.Simple
 
 --
 -- Colors
@@ -32,8 +33,6 @@ import GHC.Generics
 newtype Color a = Color (Maybe a)
   deriving (Eq, Show, Ord, Generic, Typeable, Functor, Foldable,
             Traversable)
-
-makeWrapped ''Color
 
 -- | Takes the last non-Nothing Color.  'mempty' is no color.
 instance Monoid (Color a) where

--- a/tests/colorTest.hs
+++ b/tests/colorTest.hs
@@ -1,7 +1,10 @@
 module Main where
 
-import Rainbow
 import qualified Data.ByteString as BS
+import           Rainbow
+
+import           Lens.Simple
+
 
 colors8 :: [(String, Radiant)]
 colors8 =

--- a/tests/test256color.hs
+++ b/tests/test256color.hs
@@ -1,8 +1,11 @@
 module Main where
 
-import Control.Arrow (second)
-import Rainbow
+import           Control.Arrow   (second)
 import qualified Data.ByteString as BS
+import           Rainbow
+
+import           Lens.Simple
+
 
 effects :: [(String, Chunk a -> Chunk a)]
 effects =

--- a/tests/test8color.hs
+++ b/tests/test8color.hs
@@ -1,8 +1,10 @@
 module Main where
 
-import Control.Arrow (second)
-import Rainbow
+import           Control.Arrow   (second)
 import qualified Data.ByteString as BS
+import           Rainbow
+
+import           Lens.Simple
 
 effects :: [(String, Chunk a -> Chunk a)]
 effects =


### PR DESCRIPTION
As announced in https://github.com/massysett/rainbox/pull/3 .
I'm expecting resistance on this one, due to the following backward-incompatible changes:
- lens operators are no longer re-exported
- the `Wrapped` lenses don't exist in `lens-simple`

What do you think ?